### PR TITLE
Prompt for student ID and store final scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ This repository contains `V3.html`, a browser-based game for learning the basics
 
 ## Gameplay basics
 
-- When the game loads, you will be asked to enter a name and begin training.
+- When the game loads, you will be asked to enter a name **and a nine‑digit student number** before beginning training.
 - Select complementary DNA bases from the pool (A pairs with T, G pairs with C) and click the matching position on the new strand.
 - Progress through increasing levels to complete the replication sequence. Every fifth level is a boss encounter.
+- Mutation challenge levels occur every few rounds. Use Repair bases to fix damaged DNA before pairing.
 - Watch your health and XP bars; completing sequences quickly and accurately awards experience points.
 - Use the **Check Replication** button when all bases are placed to finish a sequence.
+- Your progress is automatically saved in the browser. Returning players will be prompted to continue where they left off.
 
 ## Node environment check
 
@@ -41,4 +43,22 @@ This check is optional but helps confirm your environment can execute Node.js sc
 
 - Any up‑to‑date web browser to play the game.
 - Node.js (v18 or later recommended) if you want to run the Node check or develop additional tooling.
+
+## Saving scores and server storage
+
+Scores are stored locally in your browser under `dnaGameScores`. Each entry
+contains the player's name, student number, XP, level reached, and the date.
+
+To permanently record scores or receive an email notification you will need a
+small server or third‑party service. A few possibilities are:
+
+- **Node/Express server** – handle a `POST` request from the game and use
+  libraries such as `nodemailer` or SendGrid to email results.
+- **Google Sheets API** – create a script that appends rows to a spreadsheet for
+  each submitted score.
+- **Firebase or another hosted database** – store scores via a REST API and view
+  them later through an admin page.
+
+The game code only stores data locally; integrating one of these solutions would
+allow centralized score tracking.
 

--- a/V3.html
+++ b/V3.html
@@ -2,17 +2,19 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Origin Citadel - DNA Replication Training</title>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
   <style>
     * { box-sizing: border-box; }
-    body, html { 
-      margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; 
+    body, html {
+      margin: 0; padding: 0; width: 100%; height: 100%; overflow: auto;
       font-family: 'Inter', sans-serif; background: linear-gradient(135deg, #0f0f23, #1a1a2e, #16213e);
     }
     
-    #game-container { 
-      display: flex; width: 100%; height: 100vh; position: relative;
+    #game-container {
+      display: flex; width: 100%; max-width: 1200px; margin: auto;
+      min-height: 100vh; position: relative; padding: 0 10px;
       background: radial-gradient(ellipse at center, rgba(74,144,226,0.1) 0%, transparent 70%);
     }
     
@@ -113,6 +115,8 @@
     .base.T { background: linear-gradient(135deg, #4ecdc4, #26a69a); color: white; box-shadow: 0 0 15px rgba(78,205,196,0.4); }
     .base.G { background: linear-gradient(135deg, #45b7d1, #2196f3); color: white; box-shadow: 0 0 15px rgba(69,183,209,0.4); }
     .base.C { background: linear-gradient(135deg, #f9ca24, #f39c12); color: white; box-shadow: 0 0 15px rgba(249,202,36,0.4); }
+    .base.repair { background: linear-gradient(135deg, #9c27b0, #673ab7); color: white; box-shadow: 0 0 15px rgba(156,39,176,0.4); }
+    .mutation-marker { background: linear-gradient(135deg, #e53935, #c62828); color: white; animation: shake 1s infinite; }
     
     .base:hover { transform: translateY(-3px) scale(1.05); }
     .base:active { transform: scale(0.95); }
@@ -142,9 +146,14 @@
       animation: correctPulse 0.6s ease;
     }
     
-    .dropzone.incorrect { 
-      background: rgba(244,67,54,0.3); border-color: #f44336; 
+    .dropzone.incorrect {
+      background: rgba(244,67,54,0.3); border-color: #f44336;
       animation: shake 0.5s ease;
+    }
+
+    .dropzone.mutated {
+      background: rgba(239,83,80,0.2); border-color: #e53935;
+      animation: shake 1s infinite;
     }
     
     .dropzone.hint {
@@ -377,9 +386,12 @@
       hintsUsed: 0,
       isGameActive: false,
       playerName: '',
+      studentNumber: '',
       selectedBase: null,
       bossDamageId: null,
-      isBossLevel: false
+      isBossLevel: false,
+      mutationIndices: [],
+      mutationMap: {}
     };
 
     // Base pairing rules
@@ -404,10 +416,70 @@
       }
     ];
 
+    function saveProgress() {
+      const data = {
+        level: gameState.level,
+        health: gameState.health,
+        xp: gameState.xp,
+        playerName: gameState.playerName,
+        studentNumber: gameState.studentNumber
+      };
+      localStorage.setItem('dnaGameSave', JSON.stringify(data));
+    }
+
+    function loadProgress() {
+      const raw = localStorage.getItem('dnaGameSave');
+      if (!raw) return null;
+      try { return JSON.parse(raw); } catch(e) { return null; }
+    }
+
+    function saveFinalScore() {
+      const record = {
+        name: gameState.playerName,
+        studentNumber: gameState.studentNumber,
+        xp: gameState.xp,
+        level: gameState.level,
+        date: new Date().toISOString()
+      };
+      const raw = localStorage.getItem('dnaGameScores');
+      const scores = raw ? JSON.parse(raw) : [];
+      scores.push(record);
+      localStorage.setItem('dnaGameScores', JSON.stringify(scores));
+    }
+
+    function showContinuePrompt(saved) {
+      const overlay = document.createElement('div');
+      overlay.className = 'tutorial-overlay';
+      overlay.innerHTML = `
+        <div class="tutorial-content">
+          <h2>Continue Training?</h2>
+          <p>Resume as <strong>${saved.playerName}</strong> (ID ${saved.studentNumber}) at level ${saved.level}?</p>
+          <button class="btn btn-primary" id="continue-btn">Continue</button>
+          <button class="btn btn-secondary" id="new-btn" style="margin-left:10px;">New Game</button>
+        </div>`;
+      overlay.querySelector('#continue-btn').addEventListener('click', () => {
+        Object.assign(gameState, saved);
+        overlay.remove();
+        updateUI();
+        showLevelIntro();
+      });
+      overlay.querySelector('#new-btn').addEventListener('click', () => {
+        localStorage.removeItem('dnaGameSave');
+        overlay.remove();
+        showNamePrompt();
+      });
+      document.body.appendChild(overlay);
+    }
+
     // Initialize game
     function initGame() {
+      const saved = loadProgress();
       updateUI();
-      showNamePrompt();
+      if (saved) {
+        showContinuePrompt(saved);
+      } else {
+        showNamePrompt();
+      }
     }
 
     function showNamePrompt() {
@@ -415,8 +487,9 @@
       overlay.className = 'tutorial-overlay';
       overlay.innerHTML = `
         <div class="tutorial-content">
-          <h2>Enter Your Name</h2>
+          <h2>Enter Your Details</h2>
           <input type="text" id="player-name-input" placeholder="Your name" style="padding:8px;font-size:1em;border-radius:4px;border:none;width:80%;max-width:300px;">
+          <input type="text" id="student-number-input" placeholder="Student number" style="padding:8px;font-size:1em;border-radius:4px;border:none;width:80%;max-width:300px;margin-top:10px;">
           <div style="margin-top:20px;">
             <button class="btn btn-primary" id="start-training">Start Training</button>
           </div>
@@ -424,7 +497,13 @@
       `;
       overlay.querySelector('#start-training').addEventListener('click', () => {
         const name = overlay.querySelector('#player-name-input').value.trim() || 'Player';
+        const number = overlay.querySelector('#student-number-input').value.trim();
+        if (!/^\d{9}$/.test(number)) {
+          alert('Please enter a valid 9-digit student number.');
+          return;
+        }
         gameState.playerName = name;
+        gameState.studentNumber = number;
         overlay.remove();
         showWelcomeTutorial();
       });
@@ -437,6 +516,7 @@
       overlay.innerHTML = `
         <div class="tutorial-content">
           <h2>Welcome to DNA Replication Training, ${gameState.playerName}!</h2>
+          <p>ID: ${gameState.studentNumber}</p>
           <p>You are at the Origin Citadel, where DNA replication begins. Your mission is to help complete the replication process by matching complementary DNA bases.</p>
           
           <div class="tutorial-steps">
@@ -462,6 +542,32 @@
           <button class="btn btn-primary" onclick="this.parentElement.parentElement.remove(); startLevel(1);">Begin Training</button>
         </div>
       `;
+      document.body.appendChild(overlay);
+    }
+
+    function showLevelIntro() {
+      const desc = gameState.isBossLevel ?
+        `Boss Level ${gameState.level} - Defeat the Genome Guardian` :
+        `Level ${gameState.level}`;
+      const overlay = document.createElement('div');
+      overlay.className = 'tutorial-overlay';
+      overlay.innerHTML = `
+        <div class="tutorial-content">
+          <h2>${desc}</h2>
+          <p>Sequence Length: ${gameState.totalBases}</p>
+          <button class="btn btn-primary" id="begin-level">Begin</button>
+        </div>`;
+      overlay.querySelector('#begin-level').addEventListener('click', () => {
+        overlay.remove();
+        gameState.isGameActive = true;
+        if (gameState.isBossLevel) {
+          gameState.bossDamageId = setInterval(() => {
+            if (gameState.isGameActive) takeDamage(2 * gameState.level);
+          }, 5000);
+        }
+        if (gameState.level >= 3) startTimer();
+        saveProgress();
+      });
       document.body.appendChild(overlay);
     }
 
@@ -511,7 +617,7 @@
 
     function startLevel(level) {
       gameState.level = level;
-      gameState.isGameActive = true;
+      gameState.isGameActive = false;
       clearTimer();
 
       if (gameState.bossDamageId) {
@@ -528,6 +634,21 @@
       gameState.totalBases = sequenceLength;
       gameState.completedBases = 0;
       gameState.hintsUsed = 0;
+      gameState.mutationIndices = [];
+      gameState.mutationMap = {};
+
+      if (!gameState.isBossLevel && level % 3 === 0) {
+        const numMut = Math.min(2, Math.floor(level / 3));
+        while (gameState.mutationIndices.length < numMut) {
+          const idx = Math.floor(Math.random() * sequenceLength);
+          if (!gameState.mutationIndices.includes(idx)) {
+            gameState.mutationIndices.push(idx);
+            const realBase = gameState.currentOriginalStrand[idx];
+            gameState.mutationMap[idx] = realBase;
+            gameState.currentOriginalStrand = replaceAt(gameState.currentOriginalStrand, idx, 'X');
+          }
+        }
+      }
       
       // Update level description
       const desc = gameState.isBossLevel ?
@@ -540,21 +661,11 @@
       generateBasePool();
       updateUI();
 
-      if (gameState.isBossLevel) {
-        gameState.bossDamageId = setInterval(() => {
-          if (gameState.isGameActive) takeDamage(2 * gameState.level);
-        }, 5000);
-      }
-      
-      // Start timer for levels 3+
-      if (level >= 3) {
-        startTimer();
-      }
-      
       // Reset instruction banner
       updateInstructions('Select a base from the pool below, then click the matching spot', '1');
-      
-      showMessage(`Level ${level} started! Complete the complementary strand.`, 'info');
+
+      showLevelIntro();
+      showMessage(`Level ${level} ready!`, 'info');
     }
 
     function generateRandomSequence(length) {
@@ -563,6 +674,10 @@
         sequence += bases[Math.floor(Math.random() * 4)];
       }
       return sequence;
+    }
+
+    function replaceAt(str, idx, chr) {
+      return str.substring(0, idx) + chr + str.substring(idx + 1);
     }
 
     function createDNAStrands() {
@@ -596,10 +711,16 @@
       
       // Populate original sequence
       const originalSeq = document.getElementById('original-sequence');
-      gameState.currentOriginalStrand.split('').forEach(base => {
+      gameState.currentOriginalStrand.split('').forEach((base, idx) => {
         const baseEl = document.createElement('div');
-        baseEl.className = `base ${base}`;
-        baseEl.textContent = base;
+        baseEl.dataset.index = idx;
+        if (base === 'X') {
+          baseEl.className = 'base mutation-marker';
+          baseEl.textContent = '?';
+        } else {
+          baseEl.className = `base ${base}`;
+          baseEl.textContent = base;
+        }
         originalSeq.appendChild(baseEl);
       });
       
@@ -608,8 +729,14 @@
       gameState.currentOriginalStrand.split('').forEach((base, index) => {
         const dropzone = document.createElement('div');
         dropzone.className = 'dropzone';
-        dropzone.dataset.expected = basePairs[base];
         dropzone.dataset.position = index;
+        if (gameState.mutationIndices.includes(index)) {
+          dropzone.dataset.mutated = 'true';
+          dropzone.dataset.expected = basePairs[gameState.mutationMap[index]];
+          dropzone.classList.add('mutated');
+        } else {
+          dropzone.dataset.expected = basePairs[base];
+        }
         
         dropzone.addEventListener('dragover', handleDragOver);
         dropzone.addEventListener('drop', handleDrop);
@@ -626,8 +753,13 @@
       
       // Create needed bases plus some extras
       const neededBases = [];
-      gameState.currentOriginalStrand.split('').forEach(base => {
-        neededBases.push(basePairs[base]);
+      gameState.currentOriginalStrand.split('').forEach((base, idx) => {
+        if (base === 'X') {
+          neededBases.push('Repair');
+          neededBases.push(basePairs[gameState.mutationMap[idx]]);
+        } else {
+          neededBases.push(basePairs[base]);
+        }
       });
       
       // Add some random extra bases to make it challenging
@@ -639,8 +771,10 @@
       // Shuffle and create draggable bases
       shuffle(neededBases).forEach((base, index) => {
         const baseEl = document.createElement('div');
-        baseEl.className = `base ${base}`;
-        baseEl.textContent = base;
+        const cls = base === 'Repair' ? 'repair' : base;
+        const label = base === 'Repair' ? 'R' : base;
+        baseEl.className = `base ${cls}`;
+        baseEl.textContent = label;
         baseEl.draggable = true;
         baseEl.id = `pool-base-${index}`;
 
@@ -657,7 +791,9 @@
       e.dataTransfer.setData('element-id', e.target.id);
       e.target.classList.add('dragging');
       
-      if (gameState.level === 1) {
+      if (e.target.textContent === 'R') {
+        document.querySelectorAll('.dropzone[data-mutated="true"]').forEach(z => z.classList.add('hint'));
+      } else if (gameState.level === 1) {
         document.querySelectorAll('.dropzone:empty').forEach(zone => {
           if (zone.dataset.expected === e.target.textContent) {
             zone.classList.add('hint');
@@ -691,7 +827,9 @@
 
     function highlightValidZones(base) {
       document.querySelectorAll('.dropzone').forEach(zone => zone.classList.remove('hint'));
-      if (gameState.level === 1) {
+      if (base === 'R') {
+        document.querySelectorAll('.dropzone[data-mutated="true"]').forEach(zone => zone.classList.add('hint'));
+      } else if (gameState.level === 1) {
         document.querySelectorAll('.dropzone:empty').forEach(zone => {
           if (zone.dataset.expected === base) {
             zone.classList.add('hint');
@@ -708,8 +846,31 @@
       const droppedBase = gameState.selectedBase.textContent;
       const expectedBase = dropzone.dataset.expected;
 
+      if (dropzone.dataset.mutated === 'true') {
+        if (droppedBase === 'R') {
+          dropzone.dataset.mutated = 'false';
+          dropzone.classList.remove('mutated');
+          const orig = document.querySelector(`#original-sequence [data-index="${dropzone.dataset.position}"]`);
+          const real = gameState.mutationMap[dropzone.dataset.position];
+          if (orig) {
+            orig.textContent = real;
+            orig.className = `base ${real}`;
+          }
+          gameState.selectedBase.remove();
+          gameState.selectedBase = null;
+          highlightValidZones('');
+          showMessage('Mutation repaired! Place the correct base.', 'info');
+          updateUI();
+          return;
+        } else {
+          showMessage('Use a Repair base here first!', 'error');
+          return;
+        }
+      }
+
       dropzone.textContent = droppedBase;
-      dropzone.classList.add(droppedBase);
+      const cls = droppedBase === 'R' ? 'repair' : droppedBase;
+      dropzone.classList.add('base', cls);
 
       gameState.selectedBase.remove();
       gameState.selectedBase = null;
@@ -725,7 +886,7 @@
         playSound('incorrect');
         setTimeout(() => {
           dropzone.textContent = '';
-          dropzone.className = 'dropzone';
+          dropzone.className = 'dropzone' + (dropzone.dataset.mutated === 'true' ? ' mutated' : '');
           const pool = document.getElementById('base-pool');
           const baseEl = document.createElement('div');
           baseEl.className = `base ${droppedBase}`;
@@ -758,11 +919,17 @@
       const droppedBase = e.dataTransfer.getData('text/plain');
       const elementId = e.dataTransfer.getData('element-id');
       const expectedBase = dropzone.dataset.expected;
-      
+
       // Only allow drop if zone is empty
       if (dropzone.textContent === '') {
+        if (dropzone.dataset.mutated === 'true' && droppedBase !== 'R') {
+          showMessage('Use a Repair base here first!', 'error');
+          return;
+        }
+
         dropzone.textContent = droppedBase;
-        dropzone.classList.add(droppedBase);
+        const cls2 = droppedBase === 'R' ? 'repair' : droppedBase;
+        dropzone.classList.add('base', cls2);
         
         // Remove the base from the pool
         const poolBase = document.getElementById(elementId);
@@ -770,6 +937,28 @@
           poolBase.remove();
         }
         
+        // Handle repair drop
+        if (dropzone.dataset.mutated === 'true' && droppedBase === 'R') {
+          dropzone.dataset.mutated = 'false';
+          dropzone.textContent = '';
+          dropzone.className = 'dropzone';
+          const orig = document.querySelector(`#original-sequence [data-index="${dropzone.dataset.position}"]`);
+          const real = gameState.mutationMap[dropzone.dataset.position];
+          if (orig) {
+            orig.textContent = real;
+            orig.className = `base ${real}`;
+          }
+          playSound('correct');
+          updateUI();
+          return;
+        }
+
+        if (droppedBase === 'R' && dropzone.dataset.mutated !== 'true') {
+          showMessage('Repair base not needed here.', 'error');
+          setTimeout(() => { dropzone.textContent = ''; dropzone.className = 'dropzone' + (dropzone.dataset.mutated === 'true' ? ' mutated' : ''); }, 100);
+          return;
+        }
+
         // Check if correct
         if (droppedBase === expectedBase) {
           dropzone.classList.add('correct');
@@ -788,7 +977,7 @@
           // Return base to pool after a delay and clear dropzone
           setTimeout(() => {
             dropzone.textContent = '';
-            dropzone.className = 'dropzone';
+            dropzone.className = 'dropzone' + (dropzone.dataset.mutated === 'true' ? ' mutated' : '');
             
             // Add base back to pool
             const pool = document.getElementById('base-pool');
@@ -842,10 +1031,11 @@
 
     function handleTimeUp() {
       if (!gameState.isGameActive) return;
-      
+
       gameState.isGameActive = false;
       takeDamage(20 * gameState.level);
       showMessage("Time's up! DNA replication failed.", 'error');
+      saveProgress();
       
       setTimeout(() => {
         if (gameState.health > 0) {
@@ -885,6 +1075,7 @@
         showAchievement("Replication Master!", `Level ${gameState.level} completed perfectly!`);
 
         gameState.level++;
+        saveProgress();
         setTimeout(() => showQuiz(() => startLevel(gameState.level)), 1000);
         
       } else if (accuracy >= 0.8) {
@@ -894,6 +1085,7 @@
         showMessage(`Good replication! ${Math.floor(accuracy * 100)}% accuracy. +${xpGain} XP`, 'success');
 
         gameState.level++;
+        saveProgress();
         setTimeout(() => showQuiz(() => startLevel(gameState.level)), 1000);
         
       } else {
@@ -909,6 +1101,7 @@
           }
         }, 2500);
       }
+      saveProgress();
     }
 
     function showHint() {
@@ -1022,13 +1215,16 @@
       document.body.appendChild(overlay);
     }
 
-    function gameOver() {
+   function gameOver() {
+      saveFinalScore();
+      localStorage.removeItem('dnaGameSave');
       const overlay = document.createElement('div');
       overlay.className = 'tutorial-overlay';
       overlay.innerHTML = `
         <div class="tutorial-content">
           <h2>DNA Replication Failed!</h2>
           <p>The cellular machinery has been overwhelmed. The Origin Citadel's replication process has stopped.</p>
+          <div style="margin-bottom:10px;"><strong>${gameState.playerName}</strong> (ID ${gameState.studentNumber})</div>
           <div style="margin: 20px 0; font-size: 1.2em;">
             <div><strong>Final Level:</strong> ${gameState.level}</div>
             <div><strong>Total XP:</strong> ${gameState.xp}</div>


### PR DESCRIPTION
## Summary
- prompt for player name and 9-digit student number before starting
- include student number in progress data and continue overlay
- record final results in localStorage when the game ends
- show name and ID on welcome and game over screens
- document score saving and server options

## Testing
- `node check.js`


------
https://chatgpt.com/codex/tasks/task_e_6886efb918a8832399f024518f1861ff